### PR TITLE
feat(geocoding): add HERE Maps as fallback provider

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
             - name: Get latest tag
               id: get_latest_tag
               run: |
-                  latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+                  latest_tag=$(git tag --sort=-v:refname | head -1 || echo "v0.0.0")
                   echo "latest_tag=$latest_tag" >> "$GITHUB_OUTPUT"
 
             - name: Create new tag

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ next-env.d.ts
 *.db-wal
 *.db-shm
 backend/immich-places-backend
+backend/immich-places-backend.exe
 .wip
 immich-openapi-specs.json
 .sg

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The following Immich permissions are required:
 - `asset.update`
 - `asset.view`
 - `album.read`
+- `library.read` (if External Library is used)
 - `stack.read`
 
 ## Required environment variables

--- a/backend/config.go
+++ b/backend/config.go
@@ -20,6 +20,8 @@ type Config struct {
 	EncryptionKey       string `env:"ENCRYPTION_KEY,notEmpty"`
 	DawarichURL         string `env:"DAWARICH_URL"`
 	DefaultTimezone     string `env:"DEFAULT_TIMEZONE"`
+	GeocodeProvider     string `env:"GEOCODE_PROVIDER" envDefault:"nominatim"`
+	GeocodeAPIKey       string `env:"GEOCODE_API_KEY"`
 
 	defaultTimezoneLocation *time.Location
 }

--- a/backend/config.go
+++ b/backend/config.go
@@ -20,8 +20,9 @@ type Config struct {
 	EncryptionKey       string `env:"ENCRYPTION_KEY,notEmpty"`
 	DawarichURL         string `env:"DAWARICH_URL"`
 	DefaultTimezone     string `env:"DEFAULT_TIMEZONE"`
-	GeocodeProvider     string `env:"GEOCODE_PROVIDER" envDefault:"nominatim"`
-	GeocodeAPIKey       string `env:"GEOCODE_API_KEY"`
+	GeocodeProvider    string `env:"GEOCODE_PROVIDER" envDefault:"nominatim"`
+	GeocodeAPIKey      string `env:"GEOCODE_API_KEY"`
+	GeocodeTimeoutSecs int    `env:"GEOCODE_TIMEOUT" envDefault:"10"`
 
 	defaultTimezoneLocation *time.Location
 }

--- a/backend/geocoder.go
+++ b/backend/geocoder.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"log"
+	"strings"
+)
+
+// GeocodeProvider abstracts reverse geocoding so different services
+// (Nominatim, HERE, ...) can be swapped via configuration.
+type GeocodeProvider interface {
+	ReverseGeocode(ctx context.Context, lat, lon float64) (string, error)
+}
+
+// fallbackGeocoder tries the primary provider first; if the result looks like
+// raw coordinates or "Unknown" it falls back to the secondary provider.
+// This saves quota on paid APIs like HERE.
+type fallbackGeocoder struct {
+	primary   GeocodeProvider
+	secondary GeocodeProvider
+}
+
+func (f *fallbackGeocoder) ReverseGeocode(ctx context.Context, lat, lon float64) (string, error) {
+	label, err := f.primary.ReverseGeocode(ctx, lat, lon)
+	if err != nil {
+		return f.secondary.ReverseGeocode(ctx, lat, lon)
+	}
+	if isWeakResult(label, lat, lon) {
+		better, err := f.secondary.ReverseGeocode(ctx, lat, lon)
+		if err == nil && !isWeakResult(better, lat, lon) {
+			return better, nil
+		}
+	}
+	return label, nil
+}
+
+// isWeakResult returns true when the geocode label is just formatted
+// coordinates or the literal "Unknown" -- meaning the provider had no
+// real data for that location.
+func isWeakResult(label string, lat, lon float64) bool {
+	if label == "Unknown" {
+		return true
+	}
+	coords := formatCoords(lat, lon)
+	return strings.TrimSpace(label) == strings.TrimSpace(coords)
+}
+
+func newGeocodeProvider(provider, apiKey string) GeocodeProvider {
+	switch provider {
+	case "here":
+		if apiKey == "" {
+			log.Fatal("GEOCODE_API_KEY is required when GEOCODE_PROVIDER=here")
+		}
+		// Nominatim first, HERE as fallback to save quota
+		return &fallbackGeocoder{
+			primary:   newNominatimClient(),
+			secondary: newHereClient(apiKey),
+		}
+	case "nominatim", "":
+		return newNominatimClient()
+	default:
+		log.Printf("Unknown GEOCODE_PROVIDER %q, falling back to nominatim", provider)
+		return newNominatimClient()
+	}
+}

--- a/backend/geocoder.go
+++ b/backend/geocoder.go
@@ -4,6 +4,12 @@ import (
 	"context"
 	"log"
 	"strings"
+	"time"
+)
+
+const (
+	maxGeocodeCacheSize = 10000
+	hereReverseURL      = "https://revgeocode.search.hereapi.com/v1/revgeocode"
 )
 
 // GeocodeProvider abstracts reverse geocoding so different services
@@ -45,7 +51,7 @@ func isWeakResult(label string, lat, lon float64) bool {
 	return strings.TrimSpace(label) == strings.TrimSpace(coords)
 }
 
-func newGeocodeProvider(provider, apiKey string) GeocodeProvider {
+func newGeocodeProvider(provider, apiKey string, timeout time.Duration) GeocodeProvider {
 	switch provider {
 	case "here":
 		if apiKey == "" {
@@ -53,13 +59,13 @@ func newGeocodeProvider(provider, apiKey string) GeocodeProvider {
 		}
 		// Nominatim first, HERE as fallback to save quota
 		return &fallbackGeocoder{
-			primary:   newNominatimClient(),
-			secondary: newHereClient(apiKey),
+			primary:   newNominatimClient(timeout),
+			secondary: newHereClient(apiKey, timeout),
 		}
 	case "nominatim", "":
-		return newNominatimClient()
+		return newNominatimClient(timeout)
 	default:
 		log.Printf("Unknown GEOCODE_PROVIDER %q, falling back to nominatim", provider)
-		return newNominatimClient()
+		return newNominatimClient(timeout)
 	}
 }

--- a/backend/handlersLibraries_test.go
+++ b/backend/handlersLibraries_test.go
@@ -19,7 +19,7 @@ func newTestLibraryHandlers(t *testing.T, immichHandler http.HandlerFunc) (*Libr
 		baseURL:    server.URL,
 		httpClient: &http.Client{Timeout: 5 * time.Second},
 	}
-	syncService := newSyncService(db, factory, newNominatimClient())
+	syncService := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 	syncService.shutdownCtx = context.Background()
 	handlers := newLibraryHandlers(db, factory, syncService)
 

--- a/backend/handlers_test.go
+++ b/backend/handlers_test.go
@@ -29,7 +29,7 @@ func newTestHandlers(t *testing.T) (*Handlers, *http.ServeMux) {
 		baseURL:    "http://fake:2283",
 		httpClient: &http.Client{Timeout: 5 * time.Second},
 	}
-	syncService := newSyncService(db, factory, newNominatimClient())
+	syncService := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 	syncService.shutdownCtx = context.Background()
 	suggestions := newSuggestionService(db)
 	handlers := newHandlers(db, factory, "http://external:2283", syncService, suggestions, nil)
@@ -338,7 +338,7 @@ func newTestHandlersWithMockImmich(t *testing.T, immichHandler http.HandlerFunc)
 		baseURL:    server.URL,
 		httpClient: &http.Client{Timeout: 5 * time.Second},
 	}
-	syncService := newSyncService(db, factory, newNominatimClient())
+	syncService := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 	syncService.shutdownCtx = context.Background()
 	suggestions := newSuggestionService(db)
 	handlers := newHandlers(db, factory, "http://external:2283", syncService, suggestions, nil)

--- a/backend/hereClient.go
+++ b/backend/hereClient.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// HereClient implements GeocodeProvider using the HERE Geocoding & Search API v1.
+type HereClient struct {
+	apiKey     string
+	httpClient *http.Client
+	cache      map[string]string
+	cacheMu    sync.Mutex
+}
+
+func newHereClient(apiKey string) *HereClient {
+	return &HereClient{
+		apiKey:     apiKey,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		cache:      make(map[string]string),
+	}
+}
+
+// hereReverseResponse models the relevant fields from
+// GET https://revgeocode.search.hereapi.com/v1/revgeocode
+type hereReverseResponse struct {
+	Items []struct {
+		Title   string `json:"title"`
+		Address struct {
+			Label       string `json:"label"`
+			City        string `json:"city"`
+			State       string `json:"state"`
+			County      string `json:"county"`
+			Country     string `json:"country"`
+			CountryName string `json:"countryName"`
+		} `json:"address"`
+	} `json:"items"`
+}
+
+
+func (h *HereClient) ReverseGeocode(ctx context.Context, lat, lon float64) (string, error) {
+	key := fmt.Sprintf("%.2f,%.2f", lat, lon)
+
+	h.cacheMu.Lock()
+	if label, ok := h.cache[key]; ok {
+		h.cacheMu.Unlock()
+		return label, nil
+	}
+	h.cacheMu.Unlock()
+
+	reqURL := fmt.Sprintf(
+		"https://revgeocode.search.hereapi.com/v1/revgeocode?at=%f,%f&lang=en-US&apiKey=%s",
+		lat, lon, h.apiKey,
+	)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+	if err != nil {
+		return formatCoords(lat, lon), nil
+	}
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return formatCoords(lat, lon), nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		log.Println("HERE API rate limited (429)")
+		return formatCoords(lat, lon), nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("HERE reverse geocode returned status %d", resp.StatusCode)
+		return formatCoords(lat, lon), nil
+	}
+
+	var result hereReverseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return formatCoords(lat, lon), nil
+	}
+
+	if len(result.Items) == 0 {
+		return formatCoords(lat, lon), nil
+	}
+
+	item := result.Items[0]
+	label := buildLabel(
+		item.Address.City,
+		item.Address.County,
+		"",
+		item.Address.State,
+		item.Address.CountryName,
+	)
+
+	h.cacheMu.Lock()
+	if len(h.cache) >= maxGeocodeCacheSize {
+		h.cache = make(map[string]string)
+	}
+	h.cache[key] = label
+	h.cacheMu.Unlock()
+
+	return label, nil
+}
+

--- a/backend/hereClient.go
+++ b/backend/hereClient.go
@@ -18,10 +18,10 @@ type HereClient struct {
 	cacheMu    sync.Mutex
 }
 
-func newHereClient(apiKey string) *HereClient {
+func newHereClient(apiKey string, timeout time.Duration) *HereClient {
 	return &HereClient{
 		apiKey:     apiKey,
-		httpClient: &http.Client{Timeout: 10 * time.Second},
+		httpClient: &http.Client{Timeout: timeout},
 		cache:      make(map[string]string),
 	}
 }
@@ -42,7 +42,6 @@ type hereReverseResponse struct {
 	} `json:"items"`
 }
 
-
 func (h *HereClient) ReverseGeocode(ctx context.Context, lat, lon float64) (string, error) {
 	key := fmt.Sprintf("%.2f,%.2f", lat, lon)
 
@@ -54,8 +53,8 @@ func (h *HereClient) ReverseGeocode(ctx context.Context, lat, lon float64) (stri
 	h.cacheMu.Unlock()
 
 	reqURL := fmt.Sprintf(
-		"https://revgeocode.search.hereapi.com/v1/revgeocode?at=%f,%f&lang=en-US&apiKey=%s",
-		lat, lon, h.apiKey,
+		"%s?at=%f,%f&apiKey=%s",
+		hereReverseURL, lat, lon, h.apiKey,
 	)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
@@ -70,7 +69,7 @@ func (h *HereClient) ReverseGeocode(ctx context.Context, lat, lon float64) (stri
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusTooManyRequests {
-		log.Println("HERE API rate limited (429)")
+		log.Printf("HERE API rate limited (429)")
 		return formatCoords(lat, lon), nil
 	}
 	if resp.StatusCode != http.StatusOK {
@@ -105,4 +104,3 @@ func (h *HereClient) ReverseGeocode(ctx context.Context, lat, lon float64) (stri
 
 	return label, nil
 }
-

--- a/backend/main.go
+++ b/backend/main.go
@@ -38,8 +38,9 @@ func main() {
 	defer db.close()
 
 	immichFactory := newImmichClientFactory(cfg.ImmichURL)
-	nominatim := newNominatimClient()
-	syncService := newSyncService(db, immichFactory, nominatim)
+	geocoder := newGeocodeProvider(cfg.GeocodeProvider, cfg.GeocodeAPIKey)
+	log.Printf("Geocode provider: %s", cfg.GeocodeProvider)
+	syncService := newSyncService(db, immichFactory, geocoder)
 	suggestions := newSuggestionService(db)
 	handlers := newHandlers(db, immichFactory, cfg.ImmichExternalURL, syncService, suggestions, cfg.defaultTimezoneLocation)
 	libraryHandlers := newLibraryHandlers(db, immichFactory, syncService)

--- a/backend/main.go
+++ b/backend/main.go
@@ -38,8 +38,9 @@ func main() {
 	defer db.close()
 
 	immichFactory := newImmichClientFactory(cfg.ImmichURL)
-	geocoder := newGeocodeProvider(cfg.GeocodeProvider, cfg.GeocodeAPIKey)
-	log.Printf("Geocode provider: %s", cfg.GeocodeProvider)
+	geocodeTimeout := time.Duration(cfg.GeocodeTimeoutSecs) * time.Second
+	geocoder := newGeocodeProvider(cfg.GeocodeProvider, cfg.GeocodeAPIKey, geocodeTimeout)
+	log.Printf("Geocode provider: %s (timeout: %v)", cfg.GeocodeProvider, geocodeTimeout)
 	syncService := newSyncService(db, immichFactory, geocoder)
 	suggestions := newSuggestionService(db)
 	handlers := newHandlers(db, immichFactory, cfg.ImmichExternalURL, syncService, suggestions, cfg.defaultTimezoneLocation)

--- a/backend/migrations_test.go
+++ b/backend/migrations_test.go
@@ -113,8 +113,8 @@ func TestRunMigrationsBootstrapExistingDatabase(t *testing.T) {
 	if err := db.QueryRow("SELECT version_id FROM goose_db_version WHERE is_applied = 1 ORDER BY id DESC LIMIT 1").Scan(&version); err != nil {
 		t.Fatalf("query goose version: %v", err)
 	}
-	if version != 13 {
-		t.Errorf("expected stamped version 13, got %d", version)
+	if version != 14 {
+		t.Errorf("expected stamped version 14, got %d", version)
 	}
 
 	if _, err := db.Exec("INSERT INTO users (ID, email, passwordHash) VALUES ('u1', 'test@example.com', 'hashed')"); err != nil {

--- a/backend/nominatimClient.go
+++ b/backend/nominatimClient.go
@@ -30,7 +30,7 @@ func newNominatimClient() *NominatimClient {
 	}
 }
 
-func (n *NominatimClient) reverseGeocode(ctx context.Context, lat, lon float64) (string, error) {
+func (n *NominatimClient) ReverseGeocode(ctx context.Context, lat, lon float64) (string, error) {
 	key := fmt.Sprintf("%.2f,%.2f", lat, lon)
 
 	n.cacheMu.Lock()

--- a/backend/nominatimClient.go
+++ b/backend/nominatimClient.go
@@ -13,8 +13,6 @@ import (
 	"golang.org/x/time/rate"
 )
 
-const maxGeocodeCacheSize = 10000
-
 type NominatimClient struct {
 	httpClient *http.Client
 	cache      map[string]string
@@ -22,9 +20,9 @@ type NominatimClient struct {
 	limiter    *rate.Limiter
 }
 
-func newNominatimClient() *NominatimClient {
+func newNominatimClient(timeout time.Duration) *NominatimClient {
 	return &NominatimClient{
-		httpClient: &http.Client{Timeout: 10 * time.Second},
+		httpClient: &http.Client{Timeout: timeout},
 		cache:      make(map[string]string),
 		limiter:    rate.NewLimiter(rate.Every(time.Second), 1),
 	}

--- a/backend/syncService.go
+++ b/backend/syncService.go
@@ -24,7 +24,7 @@ const (
 type SyncService struct {
 	db                SyncStore
 	immichFactory     *ImmichClientFactory
-	nominatim         *NominatimClient
+	geocoder          GeocodeProvider
 	mu                sync.Mutex
 	userSyncing       map[string]bool
 	userCancels       map[string]context.CancelFunc
@@ -33,11 +33,11 @@ type SyncService struct {
 	freqLocGeneration atomic.Int64
 }
 
-func newSyncService(db SyncStore, factory *ImmichClientFactory, nominatim *NominatimClient) *SyncService {
+func newSyncService(db SyncStore, factory *ImmichClientFactory, geocoder GeocodeProvider) *SyncService {
 	return &SyncService{
 		db:            db,
 		immichFactory: factory,
-		nominatim:     nominatim,
+		geocoder:      geocoder,
 		userSyncing:   make(map[string]bool),
 		userCancels:   make(map[string]context.CancelFunc),
 		shutdownCtx:   context.Background(),
@@ -405,7 +405,9 @@ func (s *SyncService) recomputeFrequentLocations(ctx context.Context, userID str
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
-		s.enrichFrequentLocationLabels(ctx, userID, clusters, gen)
+		// Use shutdownCtx instead of the sync context so enrichment
+		// is not cancelled when the sync finishes.
+		s.enrichFrequentLocationLabels(s.shutdownCtx, userID, clusters, gen)
 	}()
 }
 
@@ -415,9 +417,9 @@ func (s *SyncService) enrichFrequentLocationLabels(ctx context.Context, userID s
 	for i := range clusters {
 		i := i
 		g.Go(func() error {
-			geocodeCtx, geocodeCancel := context.WithTimeout(ctx, 10*time.Second)
+			geocodeCtx, geocodeCancel := context.WithTimeout(ctx, 20*time.Second)
 			defer geocodeCancel()
-			label, err := s.nominatim.reverseGeocode(geocodeCtx, clusters[i].Latitude, clusters[i].Longitude)
+			label, err := s.geocoder.ReverseGeocode(geocodeCtx, clusters[i].Latitude, clusters[i].Longitude)
 			if err != nil {
 				log.Printf("Failed to geocode cluster: %v", err)
 				return nil

--- a/backend/syncService_test.go
+++ b/backend/syncService_test.go
@@ -193,7 +193,7 @@ func TestSyncAlbumsErrorPropagation(t *testing.T) {
 	db := newTestDB(t)
 	svc := newSyncService(db, factory, newNominatimClient())
 
-	svc.syncAlbums(context.Background(), testUserID, immich)
+	svc.syncAlbums(context.Background(), testUserID, immich, false)
 
 	var count int
 	db.db.QueryRow("SELECT COUNT(*) FROM albumAssets WHERE albumID = ?", "album1").Scan(&count)
@@ -277,7 +277,7 @@ func TestNominatimRetryAfterSeconds(t *testing.T) {
 	originalLimit := client.limiter.Limit()
 
 	ctx := context.Background()
-	result, err := client.reverseGeocode(ctx, 48.85, 2.35)
+	result, err := client.ReverseGeocode(ctx, 48.85, 2.35)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -309,7 +309,7 @@ func TestNominatimRetryAfterHTTPDate(t *testing.T) {
 	originalLimit := client.limiter.Limit()
 
 	ctx := context.Background()
-	result, err := client.reverseGeocode(ctx, 48.85, 2.35)
+	result, err := client.ReverseGeocode(ctx, 48.85, 2.35)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -988,7 +988,7 @@ func TestSyncAlbumsSuccess(t *testing.T) {
 	seedAsset(t, db, "a2", ptr(40.71), ptr(-74.0), "2024-01-02T12:00:00Z")
 
 	svc := newSyncService(db, factory, newNominatimClient())
-	err := svc.syncAlbums(ctx, testUserID, immich)
+	err := svc.syncAlbums(ctx, testUserID, immich, false)
 	if err != nil {
 		t.Fatalf("syncAlbums: %v", err)
 	}

--- a/backend/syncService_test.go
+++ b/backend/syncService_test.go
@@ -46,7 +46,7 @@ func newMockNominatimServer(t *testing.T) *NominatimClient {
 		})
 	}))
 	t.Cleanup(server.Close)
-	client := newNominatimClient()
+	client := newNominatimClient(10 * time.Second)
 	client.httpClient = server.Client()
 	client.httpClient.Transport = &rewriteTransport{
 		base: server.Client().Transport,
@@ -109,7 +109,7 @@ func TestSyncAssetsPagination(t *testing.T) {
 	})
 
 	db := newTestDB(t)
-	nom := newNominatimClient()
+	nom := newNominatimClient(10 * time.Second)
 	svc := newSyncService(db, factory, nom)
 
 	_, count, err := svc.syncAssets(ctx, testUserID, immich, nil, "test")
@@ -152,7 +152,7 @@ func TestSyncAssetsNonNumericNextPage(t *testing.T) {
 	})
 
 	db := newTestDB(t)
-	svc := newSyncService(db, factory, newNominatimClient())
+	svc := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 
 	_, _, err := svc.syncAssets(context.Background(), testUserID, immich, nil, "test")
 	if err == nil {
@@ -167,7 +167,7 @@ func TestSyncAssetsAPIError(t *testing.T) {
 	})
 
 	db := newTestDB(t)
-	svc := newSyncService(db, factory, newNominatimClient())
+	svc := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 
 	_, _, err := svc.syncAssets(context.Background(), testUserID, immich, nil, "test")
 	if err == nil {
@@ -191,7 +191,7 @@ func TestSyncAlbumsErrorPropagation(t *testing.T) {
 	})
 
 	db := newTestDB(t)
-	svc := newSyncService(db, factory, newNominatimClient())
+	svc := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 
 	svc.syncAlbums(context.Background(), testUserID, immich, false)
 
@@ -238,7 +238,7 @@ func TestSyncStacksUpdatesDB(t *testing.T) {
 	})
 
 	db := newTestDB(t)
-	svc := newSyncService(db, factory, newNominatimClient())
+	svc := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 
 	if _, _, err := svc.syncAssets(ctx, testUserID, immich, nil, "test"); err != nil {
 		t.Fatalf("syncAssets: %v", err)
@@ -267,7 +267,7 @@ func TestNominatimRetryAfterSeconds(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := newNominatimClient()
+	client := newNominatimClient(10 * time.Second)
 	client.httpClient = server.Client()
 	client.httpClient.Transport = &rewriteTransport{
 		base: server.Client().Transport,
@@ -299,7 +299,7 @@ func TestNominatimRetryAfterHTTPDate(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := newNominatimClient()
+	client := newNominatimClient(10 * time.Second)
 	client.httpClient = server.Client()
 	client.httpClient.Transport = &rewriteTransport{
 		base: server.Client().Transport,
@@ -474,7 +474,7 @@ func TestStartFullSyncSkipsIfAlreadySyncing(t *testing.T) {
 	ctx := context.Background()
 	db := newTestDB(t)
 	factory, immich := newFullMockImmichFactory(t)
-	svc := newSyncService(db, factory, newNominatimClient())
+	svc := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 
 	svc.mu.Lock()
 	svc.userSyncing[testUserID] = true
@@ -492,7 +492,7 @@ func TestRecordAndClearSyncError(t *testing.T) {
 	ctx := context.Background()
 	db := newTestDB(t)
 	factory, _ := newFullMockImmichFactory(t)
-	svc := newSyncService(db, factory, newNominatimClient())
+	svc := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 
 	svc.recordSyncError(ctx, testUserID, "test error")
 	val, _ := db.getSyncState(ctx, testUserID, "lastSyncError")
@@ -509,7 +509,7 @@ func TestRecordAndClearSyncError(t *testing.T) {
 
 func TestTryStartAndReleaseSyncLock(t *testing.T) {
 	factory, _ := newFullMockImmichFactory(t)
-	svc := newSyncService(newTestDB(t), factory, newNominatimClient())
+	svc := newSyncService(newTestDB(t), factory, newNominatimClient(10 * time.Second))
 
 	if _, ok := svc.tryStartUserSync(testUserID, func() {}); !ok {
 		t.Error("expected first start to succeed")
@@ -527,7 +527,7 @@ func TestTryStartAndReleaseSyncLock(t *testing.T) {
 
 func TestTryStartUserSyncStoresCancel(t *testing.T) {
 	factory, _ := newFullMockImmichFactory(t)
-	svc := newSyncService(newTestDB(t), factory, newNominatimClient())
+	svc := newSyncService(newTestDB(t), factory, newNominatimClient(10 * time.Second))
 
 	cancelWasCalled := false
 	cancel := func() {
@@ -555,7 +555,7 @@ func TestTryStartUserSyncStoresCancel(t *testing.T) {
 
 func TestCancelUserSyncTimesOut(t *testing.T) {
 	factory, _ := newFullMockImmichFactory(t)
-	svc := newSyncService(newTestDB(t), factory, newNominatimClient())
+	svc := newSyncService(newTestDB(t), factory, newNominatimClient(10 * time.Second))
 	svc.mu.Lock()
 	svc.userSyncing[testUserID] = true
 	svc.mu.Unlock()
@@ -568,7 +568,7 @@ func TestCancelUserSyncTimesOut(t *testing.T) {
 
 func TestCancelUserSyncWaitsForSyncToStop(t *testing.T) {
 	factory, _ := newFullMockImmichFactory(t)
-	svc := newSyncService(newTestDB(t), factory, newNominatimClient())
+	svc := newSyncService(newTestDB(t), factory, newNominatimClient(10 * time.Second))
 	svc.mu.Lock()
 	svc.userSyncing[testUserID] = true
 	svc.userCancels[testUserID] = func() {
@@ -588,7 +588,7 @@ func TestCancelUserSyncWaitsForSyncToStop(t *testing.T) {
 
 func TestPauseUserSyncReservesLock(t *testing.T) {
 	factory, _ := newFullMockImmichFactory(t)
-	svc := newSyncService(newTestDB(t), factory, newNominatimClient())
+	svc := newSyncService(newTestDB(t), factory, newNominatimClient(10 * time.Second))
 
 	if err := svc.pauseUserSync(context.Background(), testUserID); err != nil {
 		t.Fatalf("pauseUserSync: %v", err)
@@ -602,7 +602,7 @@ func TestPauseUserSyncReservesLock(t *testing.T) {
 
 func TestPauseUserSyncHonorsContextDeadline(t *testing.T) {
 	factory, _ := newFullMockImmichFactory(t)
-	svc := newSyncService(newTestDB(t), factory, newNominatimClient())
+	svc := newSyncService(newTestDB(t), factory, newNominatimClient(10 * time.Second))
 
 	if !svc.acquireUserSyncLock(testUserID) {
 		t.Fatal("expected setup lock acquisition")
@@ -686,7 +686,7 @@ func TestRunStartupSyncsStartsUsersConcurrently(t *testing.T) {
 		}
 	})
 
-	svc := newSyncService(db, factory, newNominatimClient())
+	svc := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 	users := []UserRow{
 		{ID: firstUserID, ImmichAPIKey: &firstKey},
 		{ID: secondUserID, ImmichAPIKey: &secondKey},
@@ -781,7 +781,7 @@ func TestStartPeriodicSync(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	db := newTestDB(t)
 	factory, immich := newFullMockImmichFactory(t)
-	svc := newSyncService(db, factory, newNominatimClient())
+	svc := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 
 	db.createUser(ctx, testUserID, "test@example.com", "hashed")
 	apiKey := "test-key"
@@ -858,7 +858,7 @@ func TestSyncLibraries(t *testing.T) {
 	})
 
 	db := newTestDB(t)
-	svc := newSyncService(db, factory, newNominatimClient())
+	svc := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 
 	svc.syncLibraries(ctx, testUserID, immich)
 
@@ -883,7 +883,7 @@ func TestSyncLibraries403Graceful(t *testing.T) {
 	})
 
 	db := newTestDB(t)
-	svc := newSyncService(db, factory, newNominatimClient())
+	svc := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 
 	err := svc.syncLibraries(ctx, testUserID, immich)
 	if err == nil {
@@ -919,7 +919,7 @@ func TestSyncLibraries500KeepsExistingAccessState(t *testing.T) {
 	if err := db.setSyncState(ctx, testUserID, "hasLibraryAccess", "true"); err != nil {
 		t.Fatalf("set hasLibraryAccess: %v", err)
 	}
-	svc := newSyncService(db, factory, newNominatimClient())
+	svc := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 
 	err := svc.syncLibraries(ctx, testUserID, immich)
 	if err == nil {
@@ -951,7 +951,7 @@ func TestSyncLibrariesDeletesStale(t *testing.T) {
 		http.NotFound(w, r)
 	})
 
-	svc := newSyncService(db, factory, newNominatimClient())
+	svc := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 	svc.syncLibraries(ctx, testUserID, immich)
 
 	libs, _ := db.getLibraries(ctx)
@@ -987,7 +987,7 @@ func TestSyncAlbumsSuccess(t *testing.T) {
 	seedAsset(t, db, "a1", ptr(48.85), ptr(2.35), "2024-01-01T12:00:00Z")
 	seedAsset(t, db, "a2", ptr(40.71), ptr(-74.0), "2024-01-02T12:00:00Z")
 
-	svc := newSyncService(db, factory, newNominatimClient())
+	svc := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 	err := svc.syncAlbums(ctx, testUserID, immich, false)
 	if err != nil {
 		t.Fatalf("syncAlbums: %v", err)
@@ -1027,7 +1027,7 @@ func TestDoFullSyncWithAlbumError(t *testing.T) {
 	})
 
 	db := newTestDB(t)
-	svc := newSyncService(db, factory, newNominatimClient())
+	svc := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 	svc.doUserFullSync(ctx, testUserID, immich)
 
 	errState, _ := db.getSyncState(ctx, testUserID, "lastSyncError")
@@ -1216,7 +1216,7 @@ func TestSyncStacksWithStacks(t *testing.T) {
 	seedAsset(t, db, "a1", ptr(48.85), ptr(2.35), "2024-01-01T12:00:00Z")
 	seedAsset(t, db, "a2", ptr(48.86), ptr(2.36), "2024-01-02T12:00:00Z")
 
-	svc := newSyncService(db, factory, newNominatimClient())
+	svc := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 	svc.syncStacks(ctx, testUserID, immich)
 
 	stackID, _ := db.getAssetStackID(ctx, testUserID, "a2")
@@ -1247,7 +1247,7 @@ func TestStartFullSync(t *testing.T) {
 	})
 
 	db := newTestDB(t)
-	svc := newSyncService(db, factory, newNominatimClient())
+	svc := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 	svc.startUserFullSync(ctx, testUserID, immich)
 
 	lastSync, _ := db.getSyncState(ctx, testUserID, "lastSyncAt")
@@ -1279,7 +1279,7 @@ func TestStartIncrementalSync(t *testing.T) {
 
 	db := newTestDB(t)
 	db.setSyncState(ctx, testUserID, "lastSyncAt", "2024-01-01T00:00:00Z")
-	svc := newSyncService(db, factory, newNominatimClient())
+	svc := newSyncService(db, factory, newNominatimClient(10 * time.Second))
 	svc.startUserIncrementalSync(ctx, testUserID, immich)
 
 	lastSync, _ := db.getSyncState(ctx, testUserID, "lastSyncAt")

--- a/src/app/api/geocode/search/route.ts
+++ b/src/app/api/geocode/search/route.ts
@@ -1,9 +1,12 @@
 import {NextResponse} from 'next/server';
 
 import {searchPlacesFromNominatim} from '@/features/search/nominatim';
+import {searchPlacesFromHere} from '@/features/search/here';
 import {getErrorMessage} from '@/utils/error';
 import {
 	DEFAULT_GEOCODE_RESULT_LIMIT,
+	GEOCODE_API_KEY,
+	GEOCODE_PROVIDER,
 	GEOCODE_QUERY_MAX_LENGTH,
 	GEOCODE_QUERY_MIN_LENGTH,
 	GEOCODE_UPSTREAM_TIMEOUT_MS,
@@ -50,6 +53,35 @@ async function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
 	});
 }
 
+async function doSearch(
+	query: string,
+	signal: AbortSignal,
+	acceptLanguage: string | undefined
+): Promise<TNominatimResult[]> {
+	// Always try Nominatim first (free, unlimited).
+	const nominatimResults = await searchPlacesFromNominatim(query, {
+		baseURL: GEOCODE_URL,
+		limit: MAX_RESULTS,
+		signal,
+		acceptLanguage
+	});
+	if (nominatimResults.length > 0) {
+		return nominatimResults;
+	}
+
+	// Fall back to HERE only when configured and Nominatim returned nothing.
+	if (GEOCODE_PROVIDER === 'here' && GEOCODE_API_KEY) {
+		return searchPlacesFromHere(query, {
+			apiKey: GEOCODE_API_KEY,
+			limit: MAX_RESULTS,
+			signal,
+			acceptLanguage
+		});
+	}
+
+	return nominatimResults;
+}
+
 async function attemptSearch(
 	query: string,
 	clientSignal: AbortSignal,
@@ -66,12 +98,7 @@ async function attemptSearch(
 	clientSignal.addEventListener('abort', handleClientAbort, {once: true});
 
 	try {
-		const results = await searchPlacesFromNominatim(query, {
-			baseURL: GEOCODE_URL,
-			limit: MAX_RESULTS,
-			signal: timeoutController.signal,
-			acceptLanguage
-		});
+		const results = await doSearch(query, timeoutController.signal, acceptLanguage);
 		return {results, hasTimedOut: false};
 	} catch (error) {
 		return {error, hasTimedOut};

--- a/src/features/map/hooks/useMapViewModel.ts
+++ b/src/features/map/hooks/useMapViewModel.ts
@@ -74,7 +74,7 @@ export function useMapViewModel(): TUseMapViewModelReturn {
 				if (loc.source !== 'gpx-import') {
 					return false;
 				}
-				return matchesGPXStatusFilter(gpxStatusFilter, loc.isAlreadyApplied, loc.hasExistingLocation);
+				return matchesGPXStatusFilter(gpxStatusFilter, loc.isAlreadyApplied ?? false, loc.hasExistingLocation ?? false);
 			})
 			.map(([assetID, location]) => ({
 				immichID: assetID,

--- a/src/features/search/here.ts
+++ b/src/features/search/here.ts
@@ -1,0 +1,61 @@
+import type {TNominatimResult} from '@/shared/types/nominatim';
+
+type THereSearchOptions = {
+	apiKey: string;
+	signal?: AbortSignal;
+	limit?: number;
+	acceptLanguage?: string;
+};
+
+type THereSearchItem = {
+	id: string;
+	title: string;
+	resultType: string;
+	position: {lat: number; lng: number};
+	address: {label: string};
+};
+
+type THereSearchResponse = {
+	items: THereSearchItem[];
+};
+
+/**
+ * Forward-search through the HERE Geocoding & Search API.
+ * Results are normalised into TNominatimResult so the rest of the
+ * frontend can consume them without knowing which provider was used.
+ */
+export async function searchPlacesFromHere(
+	query: string,
+	options: THereSearchOptions
+): Promise<TNominatimResult[]> {
+	const trimmed = query.trim();
+	if (!trimmed) {
+		return [];
+	}
+
+	const params = new URLSearchParams({
+		q: trimmed,
+		limit: String(options.limit ?? 5),
+		apiKey: options.apiKey
+	});
+	if (options.acceptLanguage?.trim()) {
+		params.set('lang', options.acceptLanguage.slice(0, 128));
+	}
+
+	const response = await fetch(`https://geocode.search.hereapi.com/v1/geocode?${params}`, {
+		signal: options.signal,
+		cache: 'no-store'
+	});
+	if (!response.ok) {
+		throw new Error(`HERE search failed: ${response.status}`);
+	}
+
+	const data = (await response.json()) as THereSearchResponse;
+	return (data.items ?? []).map((item, index) => ({
+		placeID: index + 1,
+		lat: String(item.position.lat),
+		lon: String(item.position.lng),
+		displayName: item.address?.label ?? item.title,
+		type: item.resultType ?? 'place'
+	}));
+}

--- a/src/features/selection/LocationConfirm.tsx
+++ b/src/features/selection/LocationConfirm.tsx
@@ -59,7 +59,7 @@ export function LocationConfirm(): ReactElement | null {
 			if (loc.source !== 'gpx-import' || loc.isAlreadyApplied) {
 				return false;
 			}
-			return matchesGPXStatusFilter(gpxStatusFilter, false, loc.hasExistingLocation);
+			return matchesGPXStatusFilter(gpxStatusFilter, false, loc.hasExistingLocation ?? false);
 		}).length;
 	}, [pendingLocationsByAssetID, gpxStatusFilter, pendingImageCount]);
 	let editedImageCount = selectedImageCount;

--- a/src/utils/geocoding.ts
+++ b/src/utils/geocoding.ts
@@ -14,13 +14,15 @@ function parseTimeoutSeconds(): number {
 	return DEFAULT_GEOCODE_TIMEOUT_S;
 }
 
+const SUPPORTED_PROVIDERS = new Set(['nominatim', 'here']);
+
 export const GEOCODE_PROVIDER = process.env.GEOCODE_PROVIDER || 'nominatim';
 export const GEOCODE_API_KEY = process.env.GEOCODE_API_KEY || '';
 export const GEOCODE_URL = process.env.GEOCODE_URL || DEFAULT_GEOCODE_URL;
 
-if (GEOCODE_PROVIDER !== 'nominatim') {
+if (!SUPPORTED_PROVIDERS.has(GEOCODE_PROVIDER)) {
 	console.warn(
-		`[geocode] Unknown GEOCODE_PROVIDER "${GEOCODE_PROVIDER}" — only "nominatim" is supported. Falling back to nominatim.`
+		`[geocode] Unknown GEOCODE_PROVIDER "${GEOCODE_PROVIDER}" — supported: ${[...SUPPORTED_PROVIDERS].join(', ')}. Falling back to nominatim.`
 	);
 }
 export const LOCAL_GEOCODE_SEARCH_PATH = '/api/geocode/search';


### PR DESCRIPTION
## Summary

Adds support for configurable geocoding providers, starting with HERE Maps as a fallback when Nominatim returns no results. This addresses the gap in OpenStreetMap's POI/business coverage without consuming paid API quota unnecessarily.

- Nominatim is always tried first (free, unlimited)
- HERE Maps is only called when Nominatim returns no results (forward search) or only coordinates/Unknown (reverse geocoding)
- Configured via `GEOCODE_PROVIDER=here` and `GEOCODE_API_KEY` environment variables
- No database changes, no breaking changes, fully backward-compatible

### Backend (Go)
- `GeocodeProvider` interface with `fallbackGeocoder` wrapping Nominatim + HERE
- `HereClient` for HERE Geocoding & Search API v1 (reverse geocoding with caching)
- `GEOCODE_PROVIDER` and `GEOCODE_API_KEY` added to config
- Fixed enrichment goroutine using shutdown context to prevent premature cancellation

### Frontend (Next.js)
- HERE forward-search client normalizing results to existing `TNominatimResult` format
- Search route tries Nominatim first, falls back to HERE on empty results
- `"here"` accepted as valid `GEOCODE_PROVIDER` value

## Configuration

```env
GEOCODE_PROVIDER=here        # default: nominatim (no changes needed)
GEOCODE_API_KEY=your_key     # required when provider is "here"
```

Both variables must be set on the backend **and** frontend containers.

### HERE free tier

HERE offers 5,000 monthly transactions for Discover/Search in the free tier. Since Nominatim is always tried first and HERE is only used as a fallback when Nominatim returns no results, actual HERE usage should be minimal. See [HERE pricing](https://www.here.com/get-started/pricing#here---platform---pricing---page-title) for details.

## Test plan

- [x] Searched for POI known to Nominatim (e.g. "Pallas Augenklinik") -- Nominatim result returned, HERE not called
- [x] Searched for POI unknown to Nominatim (e.g. "immeditech Basel") -- Nominatim returned 0 results, HERE fallback returned correct address
- [x] Reverse geocoding fallback works for frequent location labels
- [x] All existing Go tests pass
- [x] No `context canceled` errors during sync enrichment
- [x] Backward-compatible: `GEOCODE_PROVIDER=nominatim` (or unset) behaves identically to before

Closes #25