### PR TITLE
Develop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,10 +28,15 @@ ENCRYPTION_KEY=change-me-to-a-random-secret
 # Fallback timezone for GPX import when auto-detection fails (IANA format, e.g. "Europe/Vienna")
 # DEFAULT_TIMEZONE=
 
-# Geocode provider: 'nominatim' (default) or 'here'
+# Geocode provider chain: comma-separated list tried in order after Nominatim
+# Supported: nominatim, here, google (e.g. "here,google" means Nominatim -> HERE -> Google)
 # GEOCODE_PROVIDER=nominatim
 
-# API key for geocode provider (required when GEOCODE_PROVIDER=here)
+# Provider-specific API keys (preferred)
+# HERE_API_KEY=
+# GOOGLE_API_KEY=
+
+# Legacy: used as fallback if the provider-specific key above is not set
 # GEOCODE_API_KEY=
 
 # Upstream geocode request timeout in seconds (default: 10)

--- a/backend/config.go
+++ b/backend/config.go
@@ -20,9 +20,11 @@ type Config struct {
 	EncryptionKey       string `env:"ENCRYPTION_KEY,notEmpty"`
 	DawarichURL         string `env:"DAWARICH_URL"`
 	DefaultTimezone     string `env:"DEFAULT_TIMEZONE"`
-	GeocodeProvider    string `env:"GEOCODE_PROVIDER" envDefault:"nominatim"`
-	GeocodeAPIKey      string `env:"GEOCODE_API_KEY"`
-	GeocodeTimeoutSecs int    `env:"GEOCODE_TIMEOUT" envDefault:"10"`
+	GeocodeProvider     string `env:"GEOCODE_PROVIDER" envDefault:"nominatim"`
+	GeocodeAPIKey       string `env:"GEOCODE_API_KEY"`
+	HereAPIKey          string `env:"HERE_API_KEY"`
+	GoogleAPIKey        string `env:"GOOGLE_API_KEY"`
+	GeocodeTimeoutSecs  int    `env:"GEOCODE_TIMEOUT" envDefault:"10"`
 
 	defaultTimezoneLocation *time.Location
 }

--- a/backend/geocodeSearch.go
+++ b/backend/geocodeSearch.go
@@ -34,9 +34,10 @@ func (n *NominatimClient) ForwardSearch(ctx context.Context, query string, limit
 		return nil, fmt.Errorf("Nominatim request build: %w", err)
 	}
 	req.Header.Set("User-Agent", "ImmichPlaces/1.0")
-	if lang != "" {
-		req.Header.Set("Accept-Language", lang)
+	if lang == "" {
+		lang = "en"
 	}
+	req.Header.Set("Accept-Language", lang)
 
 	resp, err := n.httpClient.Do(req)
 	if err != nil {
@@ -44,6 +45,10 @@ func (n *NominatimClient) ForwardSearch(ctx context.Context, query string, limit
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusTooManyRequests {
+		n.adaptRateLimiter(resp)
+		return nil, fmt.Errorf("Nominatim rate limited (429)")
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("Nominatim search returned status %d", resp.StatusCode)
 	}
@@ -83,9 +88,10 @@ func (h *HereClient) ForwardSearch(ctx context.Context, query string, limit int,
 	params.Set("q", query)
 	params.Set("limit", strconv.Itoa(limit))
 	params.Set("apiKey", h.apiKey)
-	if lang != "" {
-		params.Set("lang", lang)
+	if lang == "" {
+		lang = "en"
 	}
+	params.Set("lang", lang)
 
 	reqURL := hereForwardURL + "?" + params.Encode()
 
@@ -100,6 +106,9 @@ func (h *HereClient) ForwardSearch(ctx context.Context, query string, limit int,
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, fmt.Errorf("HERE API rate limited (429)")
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("HERE search returned status %d", resp.StatusCode)
 	}

--- a/backend/geocoder.go
+++ b/backend/geocoder.go
@@ -10,7 +10,7 @@ import (
 const maxGeocodeCacheSize = 10000
 
 type GeocodeProvider interface {
-	ReverseGeocode(ctx context.Context, lat, lon float64) (string, error)
+	ReverseGeocode(ctx context.Context, lat, lon float64, lang string) (string, error)
 	ForwardSearch(ctx context.Context, query string, limit int, lang string) ([]SearchResult, error)
 }
 
@@ -23,10 +23,10 @@ type chainGeocoder struct {
 	chain []namedProvider
 }
 
-func (c *chainGeocoder) ReverseGeocode(ctx context.Context, lat, lon float64) (string, error) {
+func (c *chainGeocoder) ReverseGeocode(ctx context.Context, lat, lon float64, lang string) (string, error) {
 	var bestLabel string
 	for _, np := range c.chain {
-		label, err := np.provider.ReverseGeocode(ctx, lat, lon)
+		label, err := np.provider.ReverseGeocode(ctx, lat, lon, lang)
 		if err != nil {
 			log.Printf("[geocode] Reverse geocode: %s failed: %v", np.name, err)
 			continue

--- a/backend/geocoder.go
+++ b/backend/geocoder.go
@@ -7,90 +7,149 @@ import (
 	"time"
 )
 
-const (
-	maxGeocodeCacheSize = 10000
-	hereReverseURL      = "https://revgeocode.search.hereapi.com/v1/revgeocode"
-)
+const maxGeocodeCacheSize = 10000
 
-// GeocodeProvider abstracts geocoding so different services
-// (Nominatim, HERE, ...) can be swapped via configuration.
 type GeocodeProvider interface {
 	ReverseGeocode(ctx context.Context, lat, lon float64) (string, error)
 	ForwardSearch(ctx context.Context, query string, limit int, lang string) ([]SearchResult, error)
 }
 
-// fallbackGeocoder tries the primary provider first; if the result looks like
-// raw coordinates or "Unknown" it falls back to the secondary provider.
-// This saves quota on paid APIs like HERE.
-type fallbackGeocoder struct {
-	primary   GeocodeProvider
-	secondary GeocodeProvider
+type namedProvider struct {
+	name     string
+	provider GeocodeProvider
 }
 
-func (f *fallbackGeocoder) ReverseGeocode(ctx context.Context, lat, lon float64) (string, error) {
-	label, err := f.primary.ReverseGeocode(ctx, lat, lon)
-	if err != nil {
-		log.Printf("[geocode] Reverse geocode: Nominatim failed, trying HERE: %v", err)
-		return f.secondary.ReverseGeocode(ctx, lat, lon)
-	}
-	if isWeakResult(label, lat, lon) {
-		better, secErr := f.secondary.ReverseGeocode(ctx, lat, lon)
-		if secErr != nil {
-			log.Printf("[geocode] Reverse geocode: HERE failed: %v", secErr)
+type chainGeocoder struct {
+	chain []namedProvider
+}
+
+func (c *chainGeocoder) ReverseGeocode(ctx context.Context, lat, lon float64) (string, error) {
+	var bestLabel string
+	for _, np := range c.chain {
+		label, err := np.provider.ReverseGeocode(ctx, lat, lon)
+		if err != nil {
+			log.Printf("[geocode] Reverse geocode: %s failed: %v", np.name, err)
+			continue
+		}
+		if bestLabel == "" {
+			bestLabel = label
+		}
+		if !isWeakResult(label, lat, lon) {
 			return label, nil
 		}
-		if !isWeakResult(better, lat, lon) {
-			return better, nil
-		}
+		log.Printf("[geocode] Reverse geocode: %s returned weak result, trying next", np.name)
 	}
-	return label, nil
+	if bestLabel != "" {
+		return bestLabel, nil
+	}
+	return formatCoords(lat, lon), nil
 }
 
-func (f *fallbackGeocoder) ForwardSearch(ctx context.Context, query string, limit int, lang string) ([]SearchResult, error) {
-	results, err := f.primary.ForwardSearch(ctx, query, limit, lang)
-	if err != nil {
-		log.Printf("[geocode] Forward search: Nominatim failed, trying HERE: %v", err)
-		return f.secondary.ForwardSearch(ctx, query, limit, lang)
-	}
-	if len(results) == 0 {
-		log.Printf("[geocode] Forward search: Nominatim returned 0 results for %q, trying HERE", query)
-		fallbackResults, fallbackErr := f.secondary.ForwardSearch(ctx, query, limit, lang)
-		if fallbackErr != nil {
-			return nil, fallbackErr
+func (c *chainGeocoder) ForwardSearch(ctx context.Context, query string, limit int, lang string) ([]SearchResult, error) {
+	var lastErr error
+	for _, np := range c.chain {
+		results, err := np.provider.ForwardSearch(ctx, query, limit, lang)
+		if err != nil {
+			log.Printf("[geocode] Forward search: %s failed: %v", np.name, err)
+			lastErr = err
+			continue
 		}
-		log.Printf("[geocode] Forward search: HERE returned %d results for %q", len(fallbackResults), query)
-		return fallbackResults, nil
+		if len(results) == 0 {
+			log.Printf("[geocode] Forward search: %s returned 0 results for %q, trying next", np.name, query)
+			continue
+		}
+		log.Printf("[geocode] Forward search: %s returned %d results", np.name, len(results))
+		return results, nil
 	}
-	log.Printf("[geocode] Forward search: Nominatim returned %d results", len(results))
-	return results, nil
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, nil
 }
 
-// isWeakResult returns true when the geocode label is just formatted
-// coordinates or the literal "Unknown" -- meaning the provider had no
-// real data for that location.
 func isWeakResult(label string, lat, lon float64) bool {
 	if label == "Unknown" {
 		return true
 	}
-	coords := formatCoords(lat, lon)
-	return strings.TrimSpace(label) == strings.TrimSpace(coords)
+	return strings.TrimSpace(label) == formatCoords(lat, lon)
 }
 
-func newGeocodeProvider(provider, apiKey string, timeout time.Duration) GeocodeProvider {
+type geocodeKeys struct {
+	here   string
+	google string
+	legacy string
+}
+
+func resolveKey(provider string, keys geocodeKeys) string {
 	switch provider {
 	case "here":
-		if apiKey == "" {
-			log.Fatal("GEOCODE_API_KEY is required when GEOCODE_PROVIDER=here")
+		if keys.here != "" {
+			return keys.here
 		}
-		// Nominatim first, HERE as fallback to save quota
-		return &fallbackGeocoder{
-			primary:   newNominatimClient(timeout),
-			secondary: newHereClient(apiKey, timeout),
+		return keys.legacy
+	case "google":
+		if keys.google != "" {
+			return keys.google
 		}
-	case "nominatim", "":
-		return newNominatimClient(timeout)
+		return keys.legacy
 	default:
-		log.Fatalf("Unknown GEOCODE_PROVIDER %q — supported: nominatim, here", provider)
-		return nil
+		return ""
 	}
+}
+
+func describeProvider(p GeocodeProvider) string {
+	switch v := p.(type) {
+	case *chainGeocoder:
+		names := make([]string, len(v.chain))
+		for i, np := range v.chain {
+			names[i] = np.name
+		}
+		return strings.Join(names, " -> ")
+	case *NominatimClient:
+		return "Nominatim"
+	default:
+		return "unknown"
+	}
+}
+
+func newGeocodeProvider(providerStr string, keys geocodeKeys, timeout time.Duration) GeocodeProvider {
+	providerStr = strings.TrimSpace(providerStr)
+	if providerStr == "" || providerStr == "nominatim" {
+		return newNominatimClient(timeout)
+	}
+
+	chain := []namedProvider{
+		{name: "Nominatim", provider: newNominatimClient(timeout)},
+	}
+
+	providers := strings.Split(providerStr, ",")
+	for _, p := range providers {
+		p = strings.TrimSpace(p)
+		switch p {
+		case "nominatim":
+			continue
+		case "here":
+			apiKey := resolveKey(p, keys)
+			if apiKey == "" {
+				log.Fatal("HERE_API_KEY (or GEOCODE_API_KEY) is required when using here provider")
+			}
+			chain = append(chain, namedProvider{
+				name:     "HERE",
+				provider: newHereClient(apiKey, timeout),
+			})
+		case "google":
+			apiKey := resolveKey(p, keys)
+			if apiKey == "" {
+				log.Fatal("GOOGLE_API_KEY (or GEOCODE_API_KEY) is required when using google provider")
+			}
+			chain = append(chain, namedProvider{
+				name:     "Google",
+				provider: newGoogleMapsClient(apiKey, timeout),
+			})
+		default:
+			log.Fatalf("Unknown geocode provider %q — supported: nominatim, here, google", p)
+		}
+	}
+
+	return &chainGeocoder{chain: chain}
 }

--- a/backend/googleMapsClient.go
+++ b/backend/googleMapsClient.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+const googleGeocodeURL = "https://maps.googleapis.com/maps/api/geocode/json"
+
+type GoogleMapsClient struct {
+	apiKey     string
+	httpClient *http.Client
+	cache      map[string]string
+	cacheMu    sync.Mutex
+	limiter    *rate.Limiter
+}
+
+func newGoogleMapsClient(apiKey string, timeout time.Duration) *GoogleMapsClient {
+	return &GoogleMapsClient{
+		apiKey:     apiKey,
+		httpClient: &http.Client{Timeout: timeout},
+		cache:      make(map[string]string),
+		limiter:    rate.NewLimiter(rate.Every(50*time.Millisecond), 10),
+	}
+}
+
+type googleGeocodeResponse struct {
+	Status  string              `json:"status"`
+	Results []googleGeocodeItem `json:"results"`
+}
+
+type googleGeocodeItem struct {
+	PlaceID          string `json:"place_id"`
+	FormattedAddress string `json:"formatted_address"`
+	Geometry         struct {
+		Location struct {
+			Lat float64 `json:"lat"`
+			Lng float64 `json:"lng"`
+		} `json:"location"`
+	} `json:"geometry"`
+	Types             []string                 `json:"types"`
+	AddressComponents []googleAddressComponent `json:"address_components"`
+}
+
+type googleAddressComponent struct {
+	LongName string   `json:"long_name"`
+	Types    []string `json:"types"`
+}
+
+func (g *GoogleMapsClient) ReverseGeocode(ctx context.Context, lat, lon float64) (string, error) {
+	key := fmt.Sprintf("%.2f,%.2f", lat, lon)
+
+	g.cacheMu.Lock()
+	if label, ok := g.cache[key]; ok {
+		g.cacheMu.Unlock()
+		return label, nil
+	}
+	g.cacheMu.Unlock()
+
+	if err := g.limiter.Wait(ctx); err != nil {
+		return "", fmt.Errorf("Google Maps rate limiter: %w", err)
+	}
+
+	params := url.Values{}
+	params.Set("latlng", fmt.Sprintf("%f,%f", lat, lon))
+	params.Set("key", g.apiKey)
+
+	reqURL := googleGeocodeURL + "?" + params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("Google Maps request build: %w", err)
+	}
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("Google Maps request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Google Maps reverse geocode returned status %d", resp.StatusCode)
+	}
+
+	var result googleGeocodeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("Google Maps response decode: %w", err)
+	}
+
+	if err := checkGoogleStatus(result.Status); err != nil {
+		return "", err
+	}
+
+	if len(result.Results) == 0 {
+		return formatCoords(lat, lon), nil
+	}
+
+	item := result.Results[0]
+	label := buildLabelFromGoogleComponents(item.AddressComponents)
+	if label == "Unknown" {
+		label = item.FormattedAddress
+	}
+	if label == "" {
+		return formatCoords(lat, lon), nil
+	}
+
+	g.cacheMu.Lock()
+	if len(g.cache) >= maxGeocodeCacheSize {
+		g.cache = make(map[string]string)
+	}
+	g.cache[key] = label
+	g.cacheMu.Unlock()
+
+	return label, nil
+}
+
+func (g *GoogleMapsClient) ForwardSearch(ctx context.Context, query string, limit int, lang string) ([]SearchResult, error) {
+	if err := g.limiter.Wait(ctx); err != nil {
+		return nil, fmt.Errorf("Google Maps rate limiter: %w", err)
+	}
+
+	params := url.Values{}
+	params.Set("address", query)
+	params.Set("key", g.apiKey)
+	if lang == "" {
+		lang = "en"
+	}
+	params.Set("language", lang)
+
+	reqURL := googleGeocodeURL + "?" + params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("Google Maps request build: %w", err)
+	}
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Google Maps request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Google Maps search returned status %d", resp.StatusCode)
+	}
+
+	var data googleGeocodeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, fmt.Errorf("Google Maps response decode: %w", err)
+	}
+
+	if err := checkGoogleStatus(data.Status); err != nil {
+		return nil, err
+	}
+
+	items := data.Results
+	if len(items) > limit {
+		items = items[:limit]
+	}
+
+	results := make([]SearchResult, len(items))
+	for i, item := range items {
+		resultType := "place"
+		if len(item.Types) > 0 {
+			resultType = item.Types[0]
+		}
+		results[i] = SearchResult{
+			PlaceID:     i + 1,
+			Lat:         strconv.FormatFloat(item.Geometry.Location.Lat, 'f', -1, 64),
+			Lon:         strconv.FormatFloat(item.Geometry.Location.Lng, 'f', -1, 64),
+			DisplayName: item.FormattedAddress,
+			Type:        resultType,
+		}
+	}
+	return results, nil
+}
+
+func checkGoogleStatus(status string) error {
+	switch status {
+	case "OK", "ZERO_RESULTS":
+		return nil
+	case "OVER_QUERY_LIMIT":
+		return fmt.Errorf("Google Maps API rate limited (OVER_QUERY_LIMIT)")
+	case "REQUEST_DENIED":
+		return fmt.Errorf("Google Maps API request denied (check API key)")
+	default:
+		return fmt.Errorf("Google Maps API error: %s", status)
+	}
+}
+
+func buildLabelFromGoogleComponents(components []googleAddressComponent) string {
+	var city, state, country string
+	for _, c := range components {
+		for _, t := range c.Types {
+			switch t {
+			case "locality":
+				city = c.LongName
+			case "administrative_area_level_1":
+				state = c.LongName
+			case "country":
+				country = c.LongName
+			}
+		}
+	}
+	return buildLabel(city, "", "", state, country)
+}

--- a/backend/googleMapsClient.go
+++ b/backend/googleMapsClient.go
@@ -55,7 +55,7 @@ type googleAddressComponent struct {
 	Types    []string `json:"types"`
 }
 
-func (g *GoogleMapsClient) ReverseGeocode(ctx context.Context, lat, lon float64) (string, error) {
+func (g *GoogleMapsClient) ReverseGeocode(ctx context.Context, lat, lon float64, lang string) (string, error) {
 	key := fmt.Sprintf("%.2f,%.2f", lat, lon)
 
 	g.cacheMu.Lock()
@@ -69,8 +69,12 @@ func (g *GoogleMapsClient) ReverseGeocode(ctx context.Context, lat, lon float64)
 		return "", fmt.Errorf("Google Maps rate limiter: %w", err)
 	}
 
+	if lang == "" {
+		lang = "en"
+	}
 	params := url.Values{}
 	params.Set("latlng", fmt.Sprintf("%f,%f", lat, lon))
+	params.Set("language", lang)
 	params.Set("key", g.apiKey)
 
 	reqURL := googleGeocodeURL + "?" + params.Encode()

--- a/backend/handlers_test.go
+++ b/backend/handlers_test.go
@@ -1001,7 +1001,7 @@ type mockGeocoder struct {
 	callCount      int
 }
 
-func (m *mockGeocoder) ReverseGeocode(_ context.Context, _, _ float64) (string, error) {
+func (m *mockGeocoder) ReverseGeocode(_ context.Context, _, _ float64, _ string) (string, error) {
 	return "Mock Location", nil
 }
 

--- a/backend/hereClient.go
+++ b/backend/hereClient.go
@@ -44,7 +44,7 @@ type hereReverseResponse struct {
 	} `json:"items"`
 }
 
-func (h *HereClient) ReverseGeocode(ctx context.Context, lat, lon float64) (string, error) {
+func (h *HereClient) ReverseGeocode(ctx context.Context, lat, lon float64, lang string) (string, error) {
 	key := fmt.Sprintf("%.2f,%.2f", lat, lon)
 
 	h.cacheMu.Lock()
@@ -58,9 +58,12 @@ func (h *HereClient) ReverseGeocode(ctx context.Context, lat, lon float64) (stri
 		return "", fmt.Errorf("HERE rate limiter: %w", err)
 	}
 
+	if lang == "" {
+		lang = "en"
+	}
 	reqURL := fmt.Sprintf(
-		"%s?at=%f,%f&apiKey=%s",
-		hereReverseURL, lat, lon, h.apiKey,
+		"%s?at=%f,%f&lang=%s&apiKey=%s",
+		hereReverseURL, lat, lon, lang, h.apiKey,
 	)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)

--- a/backend/hereClient.go
+++ b/backend/hereClient.go
@@ -11,7 +11,8 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// HereClient implements GeocodeProvider using the HERE Geocoding & Search API v1.
+const hereReverseURL = "https://revgeocode.search.hereapi.com/v1/revgeocode"
+
 type HereClient struct {
 	apiKey     string
 	httpClient *http.Client
@@ -29,8 +30,6 @@ func newHereClient(apiKey string, timeout time.Duration) *HereClient {
 	}
 }
 
-// hereReverseResponse models the relevant fields from
-// GET https://revgeocode.search.hereapi.com/v1/revgeocode
 type hereReverseResponse struct {
 	Items []struct {
 		Title   string `json:"title"`

--- a/backend/main.go
+++ b/backend/main.go
@@ -39,8 +39,12 @@ func main() {
 
 	immichFactory := newImmichClientFactory(cfg.ImmichURL)
 	geocodeTimeout := time.Duration(cfg.GeocodeTimeoutSecs) * time.Second
-	geocoder := newGeocodeProvider(cfg.GeocodeProvider, cfg.GeocodeAPIKey, geocodeTimeout)
-	log.Printf("Geocode provider: %s (timeout: %v)", cfg.GeocodeProvider, geocodeTimeout)
+	geocoder := newGeocodeProvider(cfg.GeocodeProvider, geocodeKeys{
+		here:   cfg.HereAPIKey,
+		google: cfg.GoogleAPIKey,
+		legacy: cfg.GeocodeAPIKey,
+	}, geocodeTimeout)
+	log.Printf("Geocode provider: %s (timeout: %v)", describeProvider(geocoder), geocodeTimeout)
 	syncService := newSyncService(db, immichFactory, geocoder)
 	suggestions := newSuggestionService(db)
 	handlers := newHandlers(db, immichFactory, cfg.ImmichExternalURL, syncService, suggestions, cfg.defaultTimezoneLocation, geocoder)

--- a/backend/nominatimClient.go
+++ b/backend/nominatimClient.go
@@ -29,7 +29,7 @@ func newNominatimClient(timeout time.Duration) *NominatimClient {
 	}
 }
 
-func (n *NominatimClient) ReverseGeocode(ctx context.Context, lat, lon float64) (string, error) {
+func (n *NominatimClient) ReverseGeocode(ctx context.Context, lat, lon float64, lang string) (string, error) {
 	key := fmt.Sprintf("%.2f,%.2f", lat, lon)
 
 	n.cacheMu.Lock()
@@ -53,7 +53,10 @@ func (n *NominatimClient) ReverseGeocode(ctx context.Context, lat, lon float64) 
 		return "", fmt.Errorf("Nominatim request build: %w", err)
 	}
 	req.Header.Set("User-Agent", "ImmichPlaces/1.0")
-	req.Header.Set("Accept-Language", "en")
+	if lang == "" {
+		lang = "en"
+	}
+	req.Header.Set("Accept-Language", lang)
 
 	resp, err := n.httpClient.Do(req)
 	if err != nil {

--- a/backend/nominatimClient.go
+++ b/backend/nominatimClient.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -61,28 +62,7 @@ func (n *NominatimClient) ReverseGeocode(ctx context.Context, lat, lon float64) 
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusTooManyRequests {
-		if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
-			if seconds, err := strconv.Atoi(retryAfter); err == nil && seconds > 0 {
-				n.limiter.SetLimit(rate.Every(time.Duration(seconds) * time.Second))
-				log.Printf("Nominatim rate limited, adjusting to 1 request per %ds", seconds)
-				go func() {
-					time.Sleep(time.Duration(seconds) * time.Second)
-					n.limiter.SetLimit(rate.Every(time.Second))
-					log.Println("Nominatim rate limiter reset to 1 req/s")
-				}()
-			} else if t, err := http.ParseTime(retryAfter); err == nil {
-				delay := time.Until(t)
-				if delay > 0 {
-					n.limiter.SetLimit(rate.Every(delay))
-					log.Printf("Nominatim rate limited, adjusting to 1 request per %v", delay.Round(time.Second))
-					go func() {
-						time.Sleep(delay)
-						n.limiter.SetLimit(rate.Every(time.Second))
-						log.Println("Nominatim rate limiter reset to 1 req/s")
-					}()
-				}
-			}
-		}
+		n.adaptRateLimiter(resp)
 		return "", fmt.Errorf("Nominatim rate limited (429)")
 	}
 	if resp.StatusCode != http.StatusOK {
@@ -115,6 +95,33 @@ func (n *NominatimClient) ReverseGeocode(ctx context.Context, lat, lon float64) 
 	return label, nil
 }
 
+func (n *NominatimClient) adaptRateLimiter(resp *http.Response) {
+	retryAfter := resp.Header.Get("Retry-After")
+	if retryAfter == "" {
+		return
+	}
+	if seconds, err := strconv.Atoi(retryAfter); err == nil && seconds > 0 {
+		n.limiter.SetLimit(rate.Every(time.Duration(seconds) * time.Second))
+		log.Printf("Nominatim rate limited, adjusting to 1 request per %ds", seconds)
+		go func() {
+			time.Sleep(time.Duration(seconds) * time.Second)
+			n.limiter.SetLimit(rate.Every(time.Second))
+			log.Println("Nominatim rate limiter reset to 1 req/s")
+		}()
+	} else if t, err := http.ParseTime(retryAfter); err == nil {
+		delay := time.Until(t)
+		if delay > 0 {
+			n.limiter.SetLimit(rate.Every(delay))
+			log.Printf("Nominatim rate limited, adjusting to 1 request per %v", delay.Round(time.Second))
+			go func() {
+				time.Sleep(delay)
+				n.limiter.SetLimit(rate.Every(time.Second))
+				log.Println("Nominatim rate limiter reset to 1 req/s")
+			}()
+		}
+	}
+}
+
 func buildLabel(city, town, village, state, country string) string {
 	place := city
 	if place == "" {
@@ -138,12 +145,7 @@ func buildLabel(city, town, village, state, country string) string {
 	if len(parts) == 0 {
 		return "Unknown"
 	}
-
-	label := parts[0]
-	for i := 1; i < len(parts); i++ {
-		label += ", " + parts[i]
-	}
-	return label
+	return strings.Join(parts, ", ")
 }
 
 func formatCoords(lat, lon float64) string {

--- a/backend/syncService.go
+++ b/backend/syncService.go
@@ -416,7 +416,7 @@ func (s *SyncService) enrichFrequentLocationLabels(ctx context.Context, userID s
 		g.Go(func() error {
 			geocodeCtx, geocodeCancel := context.WithTimeout(ctx, 20*time.Second)
 			defer geocodeCancel()
-			label, err := s.geocoder.ReverseGeocode(geocodeCtx, clusters[i].Latitude, clusters[i].Longitude)
+			label, err := s.geocoder.ReverseGeocode(geocodeCtx, clusters[i].Latitude, clusters[i].Longitude, "en")
 			if err != nil {
 				log.Printf("Failed to geocode cluster: %v", err)
 				return nil

--- a/backend/syncService_test.go
+++ b/backend/syncService_test.go
@@ -277,7 +277,7 @@ func TestNominatimRetryAfterSeconds(t *testing.T) {
 	originalLimit := client.limiter.Limit()
 
 	ctx := context.Background()
-	_, err := client.ReverseGeocode(ctx, 48.85, 2.35)
+	_, err := client.ReverseGeocode(ctx, 48.85, 2.35, "en")
 	if err == nil {
 		t.Fatal("expected error on 429 response")
 	}
@@ -306,7 +306,7 @@ func TestNominatimRetryAfterHTTPDate(t *testing.T) {
 	originalLimit := client.limiter.Limit()
 
 	ctx := context.Background()
-	_, err := client.ReverseGeocode(ctx, 48.85, 2.35)
+	_, err := client.ReverseGeocode(ctx, 48.85, 2.35, "en")
 	if err == nil {
 		t.Fatal("expected error on 429 response")
 	}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,6 +16,7 @@ services:
             - '8082'
         environment:
             - IMMICH_URL=${IMMICH_URL}
+            - IMMICH_EXTERNAL_URL=${IMMICH_EXTERNAL_URL:-}
             - ENCRYPTION_KEY=${ENCRYPTION_KEY}
             - REGISTRATION_ENABLED=${REGISTRATION_ENABLED:-true}
             - SYNC_INTERVAL_MS=${SYNC_INTERVAL_MS:-300000}
@@ -23,9 +24,12 @@ services:
             - TRUST_PROXY_TLS=${TRUST_PROXY_TLS:-true}
             - ALLOW_INSECURE=${ALLOW_INSECURE:-false}
             - DEFAULT_TIMEZONE=${DEFAULT_TIMEZONE:-}
-            - GEOCODE_PROVIDER=${GEOCODE_PROVIDER:-nominatim}
+            - GEOCODE_PROVIDER=${GEOCODE_PROVIDER:-nominatim} # comma-separated chain, e.g. "here,google"
+            - HERE_API_KEY=${HERE_API_KEY:-}
+            - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
             - GEOCODE_API_KEY=${GEOCODE_API_KEY:-}
             - GEOCODE_TIMEOUT=${GEOCODE_TIMEOUT:-10}
+            - DAWARICH_URL=${DAWARICH_URL:-}
         volumes:
             - ${BACKEND_DATA_VOLUME:-backend-data}:/data
         restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
             - '8082'
         environment:
             - IMMICH_URL=${IMMICH_URL}
+            - IMMICH_EXTERNAL_URL=${IMMICH_EXTERNAL_URL:-}
             - ENCRYPTION_KEY=${ENCRYPTION_KEY}
             - REGISTRATION_ENABLED=${REGISTRATION_ENABLED:-true}
             - SYNC_INTERVAL_MS=${SYNC_INTERVAL_MS:-300000}
@@ -23,9 +24,12 @@ services:
             - TRUST_PROXY_TLS=${TRUST_PROXY_TLS:-true}
             - ALLOW_INSECURE=${ALLOW_INSECURE:-false}
             - DEFAULT_TIMEZONE=${DEFAULT_TIMEZONE:-}
-            - GEOCODE_PROVIDER=${GEOCODE_PROVIDER:-nominatim}
+            - GEOCODE_PROVIDER=${GEOCODE_PROVIDER:-nominatim} # comma-separated chain, e.g. "here,google"
+            - HERE_API_KEY=${HERE_API_KEY:-}
+            - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
             - GEOCODE_API_KEY=${GEOCODE_API_KEY:-}
             - GEOCODE_TIMEOUT=${GEOCODE_TIMEOUT:-10}
+            - DAWARICH_URL=${DAWARICH_URL:-}
         volumes:
             - ${BACKEND_DATA_VOLUME:-backend-data}:/data
         restart: unless-stopped


### PR DESCRIPTION
## Google Maps geocoding provider
- Reverse geocode via Google Geocoding API, extracts structured address components
- Forward search with index-based PlaceIDs
- Rate limiter (50ms/req, burst 10), in-memory cache

## Chain geocoder replacing fallback geocoder
- `GEOCODE_PROVIDER` now accepts comma-separated values (ex: `here,google`)
- Nominatim is always first, then providers are tried in order
- `chainGeocoder` replaces the old two-provider `fallbackGeocoder`
- `describeProvider()` for accurate startup logging

## Provider-specific API keys 
- New env vars: `HERE_API_KEY`, `GOOGLE_API_KEY`
- `GEOCODE_API_KEY` kept as legacy fallback via `resolveKey()`

## Language parameter on ReverseGeocode
- `ReverseGeocode` now accepts lang string (was hardcoded "en")
- All providers default to "en" when empty
- Sync service passes "en", HTTP handlers can pass browser language

## Rate limit handling improvements 
- Nominatim `ForwardSearch` now has adaptive 429 handling (was missing)
- HERE `ForwardSearch` now returns descriptive 429 errors
- Shared `adaptRateLimiter()` method eliminates code duplication
- All `ForwardSearch` implementations default lang to "en"

## Config/docs
- Documented chain format, provider-specific keys
- Added missing `IMMICH_EXTERNAL_URL` and `DAWARICH_URL` pass-through