### PR TITLE
Extend date range to support pre-2000 dates

### DIFF
--- a/src/features/filterBar/DateRangeFilterGroup.tsx
+++ b/src/features/filterBar/DateRangeFilterGroup.tsx
@@ -239,7 +239,7 @@ export function DateRangeFilterGroup({
 						selected={isoToDateRange(startDate, endDate)}
 						onSelect={handleCalendarSelect}
 						numberOfMonths={1}
-						startMonth={new Date(2000, 0)}
+						startMonth={new Date(1900, 0)}
 						endMonth={new Date()}
 						components={{
 							DayButton: dayButtonProps => {


### PR DESCRIPTION
## Summary
Extends the calendar date picker's supported range to include dates before 2000, enabling filtering of historical photos and events from earlier decades.

## What changed
- Updated `startMonth` parameter in the Calendar component from a more recent start year to 1900 in `DateRangeFilterGroup.tsx`, enabling users to select dates spanning back to the 1900s

## Risks
- Rendering performance may be affected when users navigate through centuries of calendar months (though the UI uses dropdown navigation to mitigate this)
- Edge cases with very old dates and timezone handling should be verified across different browsers

## Test plan
1. Open the date range filter and verify the calendar allows navigation back to years in the 1900s
2. Select a date from the 1900s and confirm it's correctly applied as a filter
3. Test year dropdown navigation to ensure smooth performance when jumping between distant years
4. Verify dates are formatted and displayed correctly in the UI for pre-2000 dates

## Docs impact
Update any user documentation or release notes that mention the supported date range if applicable

## Breaking changes
None