### PR TITLE
fix: support CARTO API keys for basemap tiles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,5 +52,9 @@ ENCRYPTION_KEY=change-me-to-a-random-secret
 # DAWARICH_URL=
 # DAWARICH_SYNC_INTERVAL_MS=86400000
 
+# CARTO basemap API key (frontend). Without it CARTO watermarks the map with
+# "API KEY REQUIRED". Free within CARTO's fair use limit: https://carto.com/basemaps/apikey/
+# CARTO_API_KEY=
+
 # Enable verbose HTTP request logging (default: false)
 # DEBUG=false

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ docker run -d --name immich-places-backend --network immich-places-net --env-fil
 docker run -d --name immich-places --network immich-places-net -p 3032:3032 -e PORT=3032 -e BACKEND_URL=http://immich-places-backend:8082 ghcr.io/majorfi/immich-places
 ```
 
+The frontend command takes its configuration from `-e` flags rather than `.env`. To set a CARTO basemap key, add `-e CARTO_API_KEY=<your-key>` to it.
+
 Then open:
 
 ```text
@@ -143,6 +145,7 @@ The following Immich permissions are required:
 - `PORT` (default `8082`): Backend listen port inside container.
 - `BACKEND_URL` (frontend): Backend service URL used by the Next.js rewrite, default is `http://backend:8082`.
 - `NEXT_PUBLIC_BACKEND_BASE` (frontend): Client API base path, default `/api/backend`.
+- `CARTO_API_KEY` (frontend): CARTO basemap API key. Without it, CARTO serves the map tiles with an "API KEY REQUIRED" watermark. Keys are free within CARTO's fair use limit — request one at [carto.com/basemaps/apikey](https://carto.com/basemaps/apikey/).
 - `DEFAULT_TIMEZONE`: IANA timezone fallback for GPX import when auto-detection fails (e.g. `Europe/Vienna`).
 - `DAWARICH_URL`: URL for Dawarich location history import integration.
 - `DAWARICH_SYNC_INTERVAL_MS` (default `86400000`): Dawarich sync frequency in milliseconds (default: 24 hours).
@@ -190,6 +193,7 @@ Configure with `GEOCODE_PROVIDER` as a comma-separated list:
 - Frontend logs: `docker compose logs -f frontend`
 - Backend logs: `docker compose logs -f backend`
 - If startup fails on `ENCRYPTION_KEY`, confirm `.env` is in the project root and contains the key.
+- If the map shows an "API KEY REQUIRED" watermark, set `CARTO_API_KEY` and recreate the frontend container: in `.env` with Docker Compose, or with `-e CARTO_API_KEY=<your-key>` on the Option B `docker run` command.
 
 ## Security usage note
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,6 +6,7 @@ services:
         environment:
             - PORT=${FRONTEND_PORT:-3032}
             - BACKEND_URL=http://backend:8082
+            - CARTO_API_KEY=${CARTO_API_KEY:-}
         depends_on:
             - backend
         restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
         environment:
             - PORT=${FRONTEND_PORT:-3032}
             - BACKEND_URL=http://backend:8082
+            - CARTO_API_KEY=${CARTO_API_KEY:-}
         depends_on:
             - backend
         restart: unless-stopped

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,7 @@ import {TileConfigProvider} from '@/features/map/TileConfigContext';
 import './globals.css';
 
 import type {Metadata} from 'next';
-import type {ReactElement} from 'react';
+import type {ReactElement, ReactNode} from 'react';
 
 /**
  * Rendered per request so `CARTO_API_KEY` is read at runtime instead of being inlined at build time.
@@ -32,7 +32,7 @@ export const metadata: Metadata = {
 export default function RootLayout({
 	children
 }: Readonly<{
-	children: React.ReactNode;
+	children: ReactNode;
 }>): ReactElement {
 	return (
 		<html lang={'en'}>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,10 +3,17 @@ import 'leaflet/dist/leaflet.css';
 import 'leaflet.markercluster/dist/MarkerCluster.css';
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
 
+import {TileConfigProvider} from '@/features/map/TileConfigContext';
+
 import './globals.css';
 
 import type {Metadata} from 'next';
 import type {ReactElement} from 'react';
+
+/**
+ * Rendered per request so `CARTO_API_KEY` is read at runtime instead of being inlined at build time.
+ */
+export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
 	title: 'Immich Places',
@@ -29,7 +36,9 @@ export default function RootLayout({
 }>): ReactElement {
 	return (
 		<html lang={'en'}>
-			<body className={`${GeistSans.variable} ${GeistSans.className}`}>{children}</body>
+			<body className={`${GeistSans.variable} ${GeistSans.className}`}>
+				<TileConfigProvider cartoAPIKey={process.env.CARTO_API_KEY ?? ''}>{children}</TileConfigProvider>
+			</body>
 		</html>
 	);
 }

--- a/src/features/auth/AuthMap.tsx
+++ b/src/features/auth/AuthMap.tsx
@@ -3,7 +3,8 @@
 import L from 'leaflet';
 import {useEffect, useRef} from 'react';
 
-import {TILE_ATTRIBUTION, TILE_URL} from '@/features/map/constant';
+import {TILE_ATTRIBUTION} from '@/features/map/constant';
+import {useStreetTileURL} from '@/features/map/TileConfigContext';
 import {MAP_DEFAULT_CENTER, MAP_DEFAULT_ZOOM, MAP_TILE_MAX_ZOOM} from '@/utils/map';
 
 import type {ReactElement} from 'react';
@@ -17,6 +18,7 @@ import type {ReactElement} from 'react';
 export function AuthMap(): ReactElement {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const mapRef = useRef<L.Map | null>(null);
+	const streetTileURL = useStreetTileURL();
 
 	useEffect(() => {
 		if (!containerRef.current || mapRef.current) {
@@ -29,7 +31,7 @@ export function AuthMap(): ReactElement {
 		}).setView(MAP_DEFAULT_CENTER, MAP_DEFAULT_ZOOM);
 
 		L.control.attribution({prefix: false}).addTo(map);
-		L.tileLayer(TILE_URL, {attribution: TILE_ATTRIBUTION, maxZoom: MAP_TILE_MAX_ZOOM}).addTo(map);
+		L.tileLayer(streetTileURL, {attribution: TILE_ATTRIBUTION, maxZoom: MAP_TILE_MAX_ZOOM}).addTo(map);
 		mapRef.current = map;
 
 		const frame = requestAnimationFrame(() => {
@@ -49,7 +51,7 @@ export function AuthMap(): ReactElement {
 			currentMap.remove();
 			mapRef.current = null;
 		};
-	}, []);
+	}, [streetTileURL]);
 
 	return (
 		<div

--- a/src/features/map/TileConfigContext.tsx
+++ b/src/features/map/TileConfigContext.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import {createContext, useContext} from 'react';
+
+import {TILE_URL} from '@/features/map/constant';
+
+import type {TTileConfigProviderProps} from '@/types/tileConfig';
+import type {ReactElement} from 'react';
+
+/**
+ * Street basemap tile URL, carrying the CARTO API key when one is configured.
+ */
+const TileConfigContext = createContext<string>(TILE_URL);
+
+/**
+ * Appends the CARTO API key to the street basemap tile URL.
+ *
+ * CARTO watermarks unauthenticated raster tiles with "API KEY REQUIRED", so the key is
+ * passed as the `key` query parameter when configured.
+ *
+ * @param cartoAPIKey - CARTO basemap API key, empty when unconfigured.
+ * @returns Tile URL template handed to Leaflet.
+ */
+function buildStreetTileURL(cartoAPIKey: string): string {
+	if (!cartoAPIKey) {
+		return TILE_URL;
+	}
+	return `${TILE_URL}?key=${encodeURIComponent(cartoAPIKey)}`;
+}
+
+/**
+ * Shares the street basemap tile URL with every map in the tree.
+ *
+ * @param props - CARTO API key resolved on the server and the child tree.
+ * @returns Provider element exposing the street tile URL.
+ */
+export function TileConfigProvider({cartoAPIKey, children}: TTileConfigProviderProps): ReactElement {
+	const streetTileURL = buildStreetTileURL(cartoAPIKey);
+
+	return <TileConfigContext.Provider value={streetTileURL}>{children}</TileConfigContext.Provider>;
+}
+
+/**
+ * Returns the street basemap tile URL for the current configuration.
+ *
+ * @returns Tile URL template, with the CARTO API key appended when configured.
+ */
+export function useStreetTileURL(): string {
+	return useContext(TileConfigContext);
+}

--- a/src/features/map/hooks/useMapViewBootstrap.ts
+++ b/src/features/map/hooks/useMapViewBootstrap.ts
@@ -3,7 +3,8 @@
 import L from 'leaflet';
 import {useEffect} from 'react';
 
-import {TILE_ATTRIBUTION, TILE_URL} from '@/features/map/constant';
+import {TILE_ATTRIBUTION} from '@/features/map/constant';
+import {useStreetTileURL} from '@/features/map/TileConfigContext';
 import {
 	MAP_BOUNDS_DEBOUNCE_MS,
 	MAP_BOUNDS_KEY_DECIMALS,
@@ -62,6 +63,8 @@ export function useMapBootstrap({
 	setMapBoundsAction,
 	clearLocationAction
 }: TUseMapBootstrapArgs): void {
+	const streetTileURL = useStreetTileURL();
+
 	useEffect(() => {
 		if (!containerRef.current || mapInstanceRef.current) {
 			return;
@@ -72,7 +75,10 @@ export function useMapBootstrap({
 			MAP_DEFAULT_ZOOM
 		);
 		L.control.attribution({prefix: false}).addTo(map);
-		const tiles = L.tileLayer(TILE_URL, {attribution: TILE_ATTRIBUTION, maxZoom: MAP_TILE_MAX_ZOOM}).addTo(map);
+		const tiles = L.tileLayer(streetTileURL, {
+			attribution: TILE_ATTRIBUTION,
+			maxZoom: MAP_TILE_MAX_ZOOM
+		}).addTo(map);
 		tileLayerRef.current = tiles;
 		mapInstanceRef.current = map;
 
@@ -100,7 +106,15 @@ export function useMapBootstrap({
 			tileLayerRef.current = null;
 			mapInstanceRef.current = null;
 		};
-	}, [boundsDebounceRef, boundsKeyRef, containerRef, mapInstanceRef, tileLayerRef, setMapBoundsAction]);
+	}, [
+		boundsDebounceRef,
+		boundsKeyRef,
+		containerRef,
+		mapInstanceRef,
+		tileLayerRef,
+		setMapBoundsAction,
+		streetTileURL
+	]);
 
 	useEffect(() => {
 		if (!mapInstanceRef.current) {

--- a/src/features/map/hooks/useMapViewController.ts
+++ b/src/features/map/hooks/useMapViewController.ts
@@ -9,8 +9,7 @@ import {
 	GEOLOCATION_UNAVAILABLE_ERROR,
 	SATELLITE_TILE_ATTRIBUTION,
 	SATELLITE_TILE_URL,
-	TILE_ATTRIBUTION,
-	TILE_URL
+	TILE_ATTRIBUTION
 } from '@/features/map/constant';
 import {useMapDropHandlers} from '@/features/map/hooks/useMapDropHandlers';
 import {useMapBootstrap} from '@/features/map/hooks/useMapViewBootstrap';
@@ -18,6 +17,7 @@ import {useMapClickHandler} from '@/features/map/hooks/useMapViewClickHandler';
 import {useMapViewRefs} from '@/features/map/hooks/useMapViewRefs';
 import {usePendingSelectionMarker} from '@/features/map/hooks/usePendingSelectionMarker';
 import {useOverviewLayer} from '@/features/map/overview/useOverviewLayer';
+import {useStreetTileURL} from '@/features/map/TileConfigContext';
 import {
 	MAP_LOCATE_ME_ZOOM,
 	MAP_LOCATION_SOURCE_DRAG_DROP,
@@ -102,6 +102,7 @@ export function useMapViewController({
 	const [mapInteractionError, setMapInteractionError] = useState<string | null>(null);
 	const [activeTileLayer, setActiveTileLayer] = useState<TMapTileLayer>('street');
 	const [mapContextMenu, setMapContextMenu] = useState<TMapContextMenuState>(null);
+	const streetTileURL = useStreetTileURL();
 
 	const {
 		mapInstanceRef,
@@ -176,13 +177,13 @@ export function useMapViewController({
 		}
 		tileLayerRef.current.remove();
 		const isSatellite = activeTileLayer === 'street';
-		const url = isSatellite ? SATELLITE_TILE_URL : TILE_URL;
+		const url = isSatellite ? SATELLITE_TILE_URL : streetTileURL;
 		const attribution = isSatellite ? SATELLITE_TILE_ATTRIBUTION : TILE_ATTRIBUTION;
 		const maxZoom = isSatellite ? MAP_SATELLITE_TILE_MAX_ZOOM : MAP_TILE_MAX_ZOOM;
 		const newTiles = L.tileLayer(url, {attribution, maxZoom}).addTo(map);
 		tileLayerRef.current = newTiles;
 		setActiveTileLayer(isSatellite ? 'satellite' : 'street');
-	}, [activeTileLayer, mapInstanceRef, tileLayerRef]);
+	}, [activeTileLayer, mapInstanceRef, streetTileURL, tileLayerRef]);
 
 	useMapBootstrap({
 		containerRef,

--- a/src/types/tileConfig.ts
+++ b/src/types/tileConfig.ts
@@ -1,0 +1,6 @@
+import type {ReactNode} from 'react';
+
+export type TTileConfigProviderProps = {
+	cartoAPIKey: string;
+	children: ReactNode;
+};


### PR DESCRIPTION
## Summary

- read `CARTO_API_KEY` at request time so prebuilt images can receive it at runtime
- append the key to CARTO street basemap requests across authenticated and unauthenticated maps
- expose the variable in Docker Compose and document its setup

Closes #62

## Validation

- `bun run build`
- ESLint on all changed TypeScript files

## Note

The repository-wide lint still reports pre-existing errors outside this change in `useMapViewModel.ts`, `PhotoCardMenu.tsx`, and `selectionStateHelpers.ts`.